### PR TITLE
explicitly mark parameter as nullable

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -98,7 +98,7 @@ final class TagRenderer
 	 *
 	 * @throws Throwable|\Psr\Cache\InvalidArgumentException
 	 */
-	public function renderLinkTags(string $entryName, string $packageName = NULL, string $entrypointName = NULL, array $extraAttributes = []): string
+	public function renderLinkTags(string $entryName, ?string $packageName = NULL, ?string $entrypointName = NULL, array $extraAttributes = []): string
 	{
 		$entryPointLookup = $this->entrypointLookupCollection->getEntrypointLookup($entrypointName);
 		$integrityHashes = $entryPointLookup instanceof IntegrityDataProviderInterface ? $entryPointLookup->getIntegrityData() : [];


### PR DESCRIPTION
since PHP v8.4,  implicitly marking parameteres as nullable is deprecated, the explicit nullable type must be used instead